### PR TITLE
relative module imports

### DIFF
--- a/fbcsp/binary.py
+++ b/fbcsp/binary.py
@@ -1,8 +1,8 @@
 import logging
 import numpy as np
 from braindecode.datautil.trial_segment import create_signal_target_from_raw_mne
-from fbcsp.lda import lda_train_scaled, lda_apply
-from fbcsp.signalproc import bandpass_mne, select_trials, select_classes, \
+from .lda import lda_train_scaled, lda_apply
+from .signalproc import bandpass_mne, select_trials, select_classes, \
     calculate_csp, apply_csp_var_log
 
 log = logging.getLogger(__name__)

--- a/fbcsp/clean.py
+++ b/fbcsp/clean.py
@@ -5,7 +5,7 @@ import itertools
 import numpy as np
 
 from braindecode.datautil.trial_segment import create_signal_target_from_raw_mne
-from fbcsp.signalproc import select_classes_cnt, select_trials_cnt, \
+from .signalproc import select_classes_cnt, select_trials_cnt, \
     extract_all_start_codes
 
 log = logging.getLogger(__name__)

--- a/fbcsp/experiment.py
+++ b/fbcsp/experiment.py
@@ -3,14 +3,14 @@ from braindecode.datautil.iterators import get_balanced_batches
 from braindecode.datautil.trial_segment import (
     create_signal_target_from_raw_mne)
 from braindecode.mne_ext.signalproc import concatenate_raws_with_events
-from fbcsp.binary import BinaryCSP
-from fbcsp.filterbank import FilterbankCSP
+from .binary import BinaryCSP
+from .filterbank import FilterbankCSP
 import numpy as np
 from numpy.random import RandomState
-from fbcsp.filterbank import generate_filterbank, filterbank_is_stable
+from .filterbank import generate_filterbank, filterbank_is_stable
 import logging
 
-from fbcsp.multiclass import MultiClassWeightedVoting
+from .multiclass import MultiClassWeightedVoting
 
 log = logging.getLogger(__name__)
 

--- a/fbcsp/filterbank.py
+++ b/fbcsp/filterbank.py
@@ -4,8 +4,8 @@ import numpy as np
 import scipy.signal
 
 from braindecode.datautil.iterators import get_balanced_batches
-from fbcsp.signalproc import concatenate_channels, select_trials
-from fbcsp.lda import lda_train_scaled, lda_apply
+from .signalproc import concatenate_channels, select_trials
+from .lda import lda_train_scaled, lda_apply
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Import internal module files by relative path instead of absolute so users can setup their python path however they want to without having to modify the cloned repository. (and also avoid having the ambiguous keywords 'examples' and 'config' in their path)